### PR TITLE
[pipeline] Implement CD using template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,12 +2,15 @@ stages:
   - test
   - build
   - publish
+  - sync
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-commits-signoffs.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-docker-deploy.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
@@ -28,6 +31,7 @@ build:docker:
       - tetra/**/*
       - setup.py
       - etc/tetra/tetra.conf.sample
+      - Dockerfile
 
 publish:image:
   variables:
@@ -37,6 +41,18 @@ publish:image:
       - tetra/**/*
       - setup.py
       - etc/tetra/tetra.conf.sample
+      - Dockerfile
+
+sync:image:
+  variables:
+    DOCKER_REPOSITORY: mendersoftware/mantra-api
+    TARGET_MANIFEST_FILE: "kubernetes/qastatus/api-deployment.yaml,kubernetes/qastatus/worker-deployment.yaml"
+  only:
+    changes:
+      - tetra/**/*
+      - setup.py
+      - etc/tetra/tetra.conf.sample
+      - Dockerfile
 
 build:docker:ui:
   extends: build:docker
@@ -54,6 +70,17 @@ publish:image:ui:
   variables:
     DOCKER_REPOSITORY: mendersoftware/mantra-ui
     DOCKER_DIR: ui
+  only:
+    changes:
+      - ui/**/*
+
+sync:image:ui:
+  extends: sync:image
+  dependencies:
+    - publish:image:ui
+  variables:
+    DOCKER_REPOSITORY: mendersoftware/mantra-ui
+    TARGET_MANIFEST_FILE: kubernetes/qastatus/ui-deployment.yaml
   only:
     changes:
       - ui/**/*


### PR DESCRIPTION
Deploy both images, taking into consideration too that API image is used
in two deployments (api and worker).

Add also missing file Dockerfile in the list for which to build API
image.