### PR TITLE
fix: allow pipelines to be run for merged PRs too

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,6 +55,7 @@ build:docker:
       - image.tar
       - image-api.tar
   rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
     - changes:
         - backend/**/*
 
@@ -81,6 +82,7 @@ build:docker:ui:
       - image.tar
       - image-ui.tar
   rules:
+    - if: $CI_COMMIT_REF_NAME == "master"
     - changes:
         - ui/**/*
 


### PR DESCRIPTION
changes won't be detected, as to gitlab the last commit might not contain triggering changes (and gitlab is unaware of the merge history)

next.