### PR TITLE
fix: fixed nightly builds retrieval order to ensure newest nightly is…

### DIFF
--- a/ui/pages/nightlies.js
+++ b/ui/pages/nightlies.js
@@ -69,7 +69,7 @@ export const getLatestNightlies = async (cutoffDate, limit = 1) => {
   const query = gql`
     query getPipeline($date: Time, $limit: Int) {
       project(fullPath: "Northern.tech/Mender/mender-qa") {
-        pipelines(source: "schedule", ref: "master", last: $limit, updatedAfter: $date) {
+        pipelines(source: "schedule", ref: "master", first: $limit, updatedAfter: $date) {
           nodes {
             path
             status


### PR DESCRIPTION
… returned, independent of the timezone the site is built in

Ticket: None
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>