### PR TITLE
QA-527: ci: Move all workloads to GCP

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,8 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
 
 test:check-python3-formatting:
+  tags:
+    - mender-qa-worker-generic-light
   stage: test
   needs: []
   image: python:3
@@ -26,6 +28,8 @@ test:check-python3-formatting:
     - TOXENV=flake8 tox
 
 test:backend-unit:
+  tags:
+    - mender-qa-worker-generic-light
   stage: test
   needs: []
   services:
@@ -97,6 +101,8 @@ build:docker:ui:
         - ui/**/*
 
 test:composition:
+  tags:
+    - mender-qa-worker-generic-light
   stage: acceptance_tests
   image: tiangolo/docker-with-compose
   needs:


### PR DESCRIPTION
By using existing tag `mender-qa-worker-generic-light`.