### PR TITLE
chore: moving to PyYAML==6.0.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -15,7 +15,7 @@ pbr==5.8.1
 psycopg2==2.8.6
 python-mimeparse==1.6.0
 pytz==2021.3
-PyYAML==6.0
+PyYAML==6.0.1
 rfc3986==1.5.0
 six==1.16.0
 SQLAlchemy==1.3.24


### PR DESCRIPTION
the 6.0 causes:

```
AttributeError: cython_sources
```

see:
https://northern-tech.slack.com/archives/C0XM0KX9C/p1689652088065289 https://northern-tech.slack.com/archives/C0XM0KX9C/p1689667137865079


Ticket: None