### PR TITLE
feat(nightlies): add 4.1.x nightly pipeline schedules

### DIFF
--- a/ui/pages/build-status.js
+++ b/ui/pages/build-status.js
@@ -46,9 +46,9 @@ const repos = [
     isExecutable: false,
     isProduct: true,
     area: areas.backend,
-    supportedBranches: ['4.0.x']
+    supportedBranches: ['4.0.x', '4.1.x']
   },
-  { repo: 'mender-server', branches: ['main'], staging: false, isExecutable: false, isProduct: true, area: areas.backend, supportedBranches: ['4.0.x'] },
+  { repo: 'mender-server', branches: ['main'], staging: false, isExecutable: false, isProduct: true, area: areas.backend, supportedBranches: ['4.0.x', '4.1.x'] },
   { repo: 'mender-setup', staging: false, isExecutable: false, isProduct: true, area: areas.client },
   { repo: 'mender-snapshot', staging: false, isExecutable: false, isProduct: true, area: areas.client },
   { repo: 'mender-stress-test-client', staging: false, isExecutable: false, isProduct: false, area: areas.qa },

--- a/ui/pages/nightlies.js
+++ b/ui/pages/nightlies.js
@@ -99,6 +99,11 @@ export const pipelines = [
     pipelineScheduleId: 2766723
   },
   {
+    name: 'Full integration mender-server:4.1.x',
+    projectPath: 'Northern.tech/Mender/integration',
+    pipelineScheduleId: 4188082
+  },
+  {
     name: 'Mender Client Acceptance Tests',
     projectPath: 'Northern.tech/Mender/mender-qa',
     pipelineScheduleId: 30585
@@ -109,9 +114,19 @@ export const pipelines = [
     pipelineScheduleId: 2738797
   },
   {
+    name: 'Integration mender-server-enterprise:4.1.x',
+    projectPath: 'Northern.tech/Mender/mender-server-enterprise',
+    pipelineScheduleId: 4187887
+  },
+  {
     name: 'mender-server',
     projectPath: 'Northern.tech/Mender/mender-server',
     pipelineScheduleId: 2738796
+  },
+  {
+    name: 'Integration mender-server:4.1.x',
+    projectPath: 'Northern.tech/Mender/mender-server',
+    pipelineScheduleId: 4187881
   },
   {
     name: 'mender-gateway:master (w/ client latest)',


### PR DESCRIPTION
Add pipeline schedule entries for mender-server, mender-server-enterprise, and integration repo on 4.1.x, and include 4.1.x in supported branches.


Ticket: QA-1521