### PR TITLE
fix(build-status): track mender-orchestrator on main branch

### DIFF
--- a/ui/pages/build-status.js
+++ b/ui/pages/build-status.js
@@ -38,7 +38,7 @@ const repos = [
   { repo: 'mender-helm', staging: false, isExecutable: false, isProduct: false, area: areas.saas, supportedBranches: ['5.x'] },
   { repo: 'mender-image-tests', staging: false, isExecutable: false, isProduct: false, area: areas.client },
   { repo: 'mender-mcu', branches: ['main'], staging: false, isExecutable: true, isProduct: true, area: areas.client },
-  { repo: 'mender-orchestrator', staging: false, isExecutable: true, isProduct: true, area: areas.client },
+  { repo: 'mender-orchestrator', branches: ['main'], staging: false, isExecutable: true, isProduct: true, area: areas.client },
   {
     repo: 'mender-server-enterprise',
     branches: ['main'],


### PR DESCRIPTION
  `mender-orchestrator` repo moved to main but mantra still defaults to master.

  Signed-off-by: Patryk Targowicz <patryk.targowicz@northern.tech>
  Ticket: QA-1568