### PR TITLE
fix: survive GitLab GraphQL outages in the nightlies build and Slack report

### DIFF
--- a/scripts/send-slack-notification.ts
+++ b/scripts/send-slack-notification.ts
@@ -263,13 +263,20 @@ const main = async () => {
   const missingFiles = loadedFiles.filter(({ data }) => !data).map(({ filePath }) => filePath);
   const availableFiles = loadedFiles.filter(({ data }) => !!data);
 
+  const today = new Intl.DateTimeFormat('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
+  const header: SlackBlock = { type: 'header', text: { type: 'plain_text', text: `Build Status - ${today}` } };
+  const pipelineUrl = Deno.env.get('CI_PIPELINE_URL');
+  const pipelineLink = pipelineUrl ? ` <${pipelineUrl}|Pipeline>` : '';
+
+  // say so rather than going quiet - a missing report is easily mistaken for everything being fine
   if (!availableFiles.length) {
-    console.error('[ERROR] None of the build status files could be read - skipping the notification entirely');
+    console.error('[ERROR] None of the build status files could be read');
+    const text = `🚨 *No build status to report.* The ui build did not produce ${missingFiles.join(' or ')}, so there is nothing to check against.${pipelineLink}`;
+    await sendToSlackWithRetry(webhookUrl, { blocks: [header, { type: 'section', text: { type: 'mrkdwn', text } }] });
     Deno.exit(1);
   }
 
-  const today = new Intl.DateTimeFormat('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
-  await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'header', text: { type: 'plain_text', text: `Build Status - ${today}` } }] });
+  await sendToSlackWithRetry(webhookUrl, { blocks: [header] });
 
   for (const { data } of availableFiles) {
     for (const [index, areaName] of areas.entries()) {
@@ -289,7 +296,7 @@ const main = async () => {
   }
 
   if (missingFiles.length) {
-    const text = `⚠️ No data for ${missingFiles.join(', ')} - the ui build likely failed, so this report is incomplete.`;
+    const text = `⚠️ *This report is incomplete.* No data for ${missingFiles.join(', ')}, the ui build likely failed.${pipelineLink}`;
     await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }] });
   }
 

--- a/scripts/send-slack-notification.ts
+++ b/scripts/send-slack-notification.ts
@@ -73,13 +73,15 @@ interface SlackMessage {
   blocks: SlackBlock[];
 }
 
-const loadRepoStatus = async (filePath: string): Promise<RepoStatusFile> => {
+// a missing or malformed file means the ui build that produces it failed - report on whatever else we do have
+// instead of losing the entire status update over it
+const loadRepoStatus = async (filePath: string): Promise<RepoStatusFile | null> => {
   try {
     const data = await Deno.readTextFile(filePath);
     return JSON.parse(data);
   } catch (error) {
-    console.error('[ERROR] Failed to parse repoStatus:', error);
-    throw error;
+    console.error(`[ERROR] Failed to load ${filePath}:`, error);
+    return null;
   }
 };
 
@@ -256,14 +258,23 @@ const main = async () => {
     console.error('[ERROR] SLACK_WEBHOOK_URL environment variable not set');
     Deno.exit(1);
   }
+  // gather everything up front, so we only announce a build status we can actually follow up on
+  const loadedFiles = await Promise.all(buildStatusFiles.map(async filePath => ({ filePath, data: await loadRepoStatus(filePath) })));
+  const missingFiles = loadedFiles.filter(({ data }) => !data).map(({ filePath }) => filePath);
+  const availableFiles = loadedFiles.filter(({ data }) => !!data);
+
+  if (!availableFiles.length) {
+    console.error('[ERROR] None of the build status files could be read - skipping the notification entirely');
+    Deno.exit(1);
+  }
+
   const today = new Intl.DateTimeFormat('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
   await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'header', text: { type: 'plain_text', text: `Build Status - ${today}` } }] });
 
-  for (const filePath of buildStatusFiles) {
-    const data = await loadRepoStatus(filePath);
+  for (const { data } of availableFiles) {
     for (const [index, areaName] of areas.entries()) {
-      const area = data[areaName]!;
-      if (!area) {
+      const area = data![areaName] as AreaData;
+      if (!area?.repos?.length) {
         continue;
       }
       console.log(`\n[INFO] Processing ${areaName} area`);
@@ -277,8 +288,18 @@ const main = async () => {
     }
   }
 
+  if (missingFiles.length) {
+    const text = `⚠️ No data for ${missingFiles.join(', ')} - the ui build likely failed, so this report is incomplete.`;
+    await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }] });
+  }
+
   const moodEnhancer = await getMoodEnhancer();
   await sendToSlackWithRetry(webhookUrl, moodEnhancer);
+
+  if (missingFiles.length) {
+    console.error(`\n[ERROR] Notifications sent, but ${missingFiles.join(', ')} could not be read - failing the job to keep this visible`);
+    Deno.exit(1);
+  }
 
   console.log('\n[INFO] All notifications sent successfully');
 };

--- a/ui/pages/build-status.js
+++ b/ui/pages/build-status.js
@@ -3,10 +3,11 @@ import { Accordion, AccordionDetails, AccordionSummary, Stack, Typography } from
 
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import { gql, request } from 'graphql-request';
+import { gql } from 'graphql-request';
 
 import Link from '../components/link';
 import { buildStatusColor } from '../src/constants';
+import { requestWithRetry } from '../src/graphql';
 
 const areas = {
   backend: 'backend',
@@ -289,7 +290,7 @@ const getAllRepos = async () => {
   let hasNextPage = true;
 
   while (hasNextPage) {
-    const repoState = await request({
+    const repoState = await requestWithRetry({
       url: githubGraphqlUrl,
       variables: { login: 'mendersoftware', cursor },
       document: repoQuery,
@@ -374,7 +375,7 @@ const getAllProjects = async (group, ref) => {
   let hasNextPage = true;
 
   while (hasNextPage) {
-    const data = await request({
+    const data = await requestWithRetry({
       url: gitlabGraphqlUrl,
       document: pipelineQuery,
       variables: { group: `Northern.tech/${group}`, ref, cursor },

--- a/ui/pages/nightlies.js
+++ b/ui/pages/nightlies.js
@@ -5,8 +5,9 @@ import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
 
 import dayjs from 'dayjs';
 import fs from 'fs/promises';
-import { gql, request } from 'graphql-request';
+import { gql } from 'graphql-request';
 
+import { requestWithRetry } from '../src/graphql';
 import { PipelineCalendar } from '../src/nightlies/CalendarView';
 import { Legend } from '../src/nightlies/Legend';
 import { PipelineListView } from '../src/nightlies/ListView';
@@ -180,15 +181,18 @@ const calculateRetryInfo = jobs => {
   };
 };
 
-const emptyDetails = {
+// keep the pipeline identity around even when we couldn't enrich it, so the repo can still be named and linked
+// downstream - an absent buildStatus would fail the static export, as `undefined` is not serializable
+const emptyDetails = pipeline => ({
   testReportSummary: { total: { failed: 0 } },
   hasRetries: false,
-  retriedJobCount: 0
-};
+  retriedJobCount: 0,
+  buildStatus: { name: pipeline.name, fullPath: pipeline.projectPath, status: '' }
+});
 const getPipelineDetails = async (pipeline, pipelineIid) => {
   let pipelineData;
   try {
-    const data = await request({
+    const data = await requestWithRetry({
       url: gitlabGraphqlUrl,
       document: pipelineEnrichmentQuery,
       variables: {
@@ -200,11 +204,11 @@ const getPipelineDetails = async (pipeline, pipelineIid) => {
     pipelineData = data?.project?.pipeline;
   } catch (error) {
     console.error(`(${pipeline.name}): GraphQL query failed for pipeline ${pipelineIid}:`, error);
-    return emptyDetails;
+    return emptyDetails(pipeline);
   }
   if (!pipelineData) {
     console.warn(`Failed to fetch details for pipeline ${pipelineIid}`);
-    return emptyDetails;
+    return emptyDetails(pipeline);
   }
   const retryInfo = calculateRetryInfo(pipelineData.jobs?.nodes || []);
   const failedJobs = (pipelineData.jobs?.nodes || []).filter(({ status }) => status === 'FAILED');

--- a/ui/src/graphql.js
+++ b/ui/src/graphql.js
@@ -1,0 +1,26 @@
+import { request } from 'graphql-request';
+
+const maxRetries = 3;
+
+// GitLab and GitHub regularly answer with a 502/503 from their edge, occasionally rate limit us and sometimes just
+// drop the connection - none of which says anything about the query itself, so those are worth another attempt
+const isRetriable = error => {
+  const status = error?.response?.status;
+  return status === undefined || status === 429 || status >= 500;
+};
+
+export const requestWithRetry = async options => {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await request(options);
+    } catch (error) {
+      if (attempt === maxRetries || !isRetriable(error)) {
+        throw error;
+      }
+      const delay = Math.pow(2, attempt) * 1000;
+      const reason = error?.response?.status ?? 'a network error';
+      console.warn(`(GraphQL ${new URL(options.url).host}): attempt ${attempt}/${maxRetries} failed with ${reason}, retrying in ${delay}ms`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+};


### PR DESCRIPTION
## What happened

On 21.07.2026 the build status Slack message was just a header with no content. Two independent faults lined up.

**Root cause.** GitLab's GraphQL endpoint answered a `getPipelineDetails` query for `mender-server-enterprise` with a 502 from its edge. That path returns `emptyDetails`, which had no `buildStatus` key, so the entry came back as `undefined` and Next refused to serialize it:

```
Error serializing `.nightlies["mender-server-enterprise"][0][14].buildStatus`
       returned from `getStaticProps` in "/nightlies".
Export encountered an error on /nightlies, exiting the build.
```

`build:docker-multiplatform:ui` failed, so `ui/nightliesBuildStatus.json` was never produced.

**Second fault.** `notify:slack:build-status` sends the header *before* reading any data, then threw on the missing file and exited. Result: an orphaned header, and no report at all, not even for the areas whose data was present.

This was not a one-off. Pipeline `2692366159` (04:32 UTC) died the same way on `mender-server-enterprise:4.1.x`.

## Changes

- `ui/pages/nightlies.js` — `emptyDetails` now carries `buildStatus` with the pipeline's name and path, so a failed enrichment degrades that repo to *pending* instead of breaking the export. Keeping the name matters: `nightliesBuildStatus.json` reads `buildStatus.name`, so a bare `{}` would surface in Slack as `*undefined*`.
- `ui/src/graphql.js` — new `requestWithRetry`: 3 attempts with exponential backoff on 5xx/429/network errors, and deliberately **no** retry on 4xx, since an expired token will not start working on its own.
- `ui/pages/build-status.js` — retry wired into both remaining GraphQL call sites.
- `scripts/send-slack-notification.ts` — loads the status files up front; skips the header entirely when none can be read, reports whatever is available otherwise, and names what is missing. Still exits non-zero so the job stays red.

## Verification

- `deno check` passes on the notification script.
- Notifier exercised end-to-end against a mock webhook in three scenarios: both files present (unchanged full report), nightlies missing (header + Backend + Qa + a gap warning, exit 1), both missing (zero posts, exit 1).
- Retry helper covered against a local server: passes through success without retrying, recovers from a transient 502, gives up after 3, and does not retry a 401.
- The degraded `/nightlies` path was driven with a stubbed `fetch` (REST succeeds, GraphQL 502s) and the result run through Next's own `isSerializableProps`. It passes with this change and reproduces the production error verbatim without it.
