### PR TITLE
fix(notifications): report partial/empty build status instead of a bare header

### DIFF
--- a/scripts/send-slack-notification.ts
+++ b/scripts/send-slack-notification.ts
@@ -263,13 +263,20 @@ const main = async () => {
   const missingFiles = loadedFiles.filter(({ data }) => !data).map(({ filePath }) => filePath);
   const availableFiles = loadedFiles.filter(({ data }) => !!data);
 
+  const today = new Intl.DateTimeFormat('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
+  const header: SlackBlock = { type: 'header', text: { type: 'plain_text', text: `Build Status - ${today}` } };
+  const pipelineUrl = Deno.env.get('CI_PIPELINE_URL');
+  const pipelineLink = pipelineUrl ? ` <${pipelineUrl}|Pipeline>` : '';
+
+  // say so rather than going quiet - a missing report is easily mistaken for everything being fine
   if (!availableFiles.length) {
-    console.error('[ERROR] None of the build status files could be read - skipping the notification entirely');
+    console.error('[ERROR] None of the build status files could be read');
+    const text = `🚨 *No build status to report.* The ui build did not produce ${missingFiles.join(' or ')}, so there is nothing to check against.${pipelineLink}`;
+    await sendToSlackWithRetry(webhookUrl, { blocks: [header, { type: 'section', text: { type: 'mrkdwn', text } }] });
     Deno.exit(1);
   }
 
-  const today = new Intl.DateTimeFormat('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
-  await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'header', text: { type: 'plain_text', text: `Build Status - ${today}` } }] });
+  await sendToSlackWithRetry(webhookUrl, { blocks: [header] });
 
   for (const { data } of availableFiles) {
     for (const [index, areaName] of areas.entries()) {
@@ -289,7 +296,7 @@ const main = async () => {
   }
 
   if (missingFiles.length) {
-    const text = `⚠️ No data for ${missingFiles.join(', ')} - the ui build likely failed, so this report is incomplete.`;
+    const text = `⚠️ *This report is incomplete.* No data for ${missingFiles.join(', ')}, the ui build likely failed.${pipelineLink}`;
     await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }] });
   }
 

--- a/scripts/send-slack-notification.ts
+++ b/scripts/send-slack-notification.ts
@@ -73,13 +73,15 @@ interface SlackMessage {
   blocks: SlackBlock[];
 }
 
-const loadRepoStatus = async (filePath: string): Promise<RepoStatusFile> => {
+// a missing or malformed file means the ui build that produces it failed - report on whatever else we do have
+// instead of losing the entire status update over it
+const loadRepoStatus = async (filePath: string): Promise<RepoStatusFile | null> => {
   try {
     const data = await Deno.readTextFile(filePath);
     return JSON.parse(data);
   } catch (error) {
-    console.error('[ERROR] Failed to parse repoStatus:', error);
-    throw error;
+    console.error(`[ERROR] Failed to load ${filePath}:`, error);
+    return null;
   }
 };
 
@@ -256,14 +258,23 @@ const main = async () => {
     console.error('[ERROR] SLACK_WEBHOOK_URL environment variable not set');
     Deno.exit(1);
   }
+  // gather everything up front, so we only announce a build status we can actually follow up on
+  const loadedFiles = await Promise.all(buildStatusFiles.map(async filePath => ({ filePath, data: await loadRepoStatus(filePath) })));
+  const missingFiles = loadedFiles.filter(({ data }) => !data).map(({ filePath }) => filePath);
+  const availableFiles = loadedFiles.filter(({ data }) => !!data);
+
+  if (!availableFiles.length) {
+    console.error('[ERROR] None of the build status files could be read - skipping the notification entirely');
+    Deno.exit(1);
+  }
+
   const today = new Intl.DateTimeFormat('nb-NO', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
   await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'header', text: { type: 'plain_text', text: `Build Status - ${today}` } }] });
 
-  for (const filePath of buildStatusFiles) {
-    const data = await loadRepoStatus(filePath);
+  for (const { data } of availableFiles) {
     for (const [index, areaName] of areas.entries()) {
-      const area = data[areaName]!;
-      if (!area) {
+      const area = data![areaName] as AreaData;
+      if (!area?.repos?.length) {
         continue;
       }
       console.log(`\n[INFO] Processing ${areaName} area`);
@@ -277,8 +288,18 @@ const main = async () => {
     }
   }
 
+  if (missingFiles.length) {
+    const text = `⚠️ No data for ${missingFiles.join(', ')} - the ui build likely failed, so this report is incomplete.`;
+    await sendToSlackWithRetry(webhookUrl, { blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }] });
+  }
+
   const moodEnhancer = await getMoodEnhancer();
   await sendToSlackWithRetry(webhookUrl, moodEnhancer);
+
+  if (missingFiles.length) {
+    console.error(`\n[ERROR] Notifications sent, but ${missingFiles.join(', ')} could not be read - failing the job to keep this visible`);
+    Deno.exit(1);
+  }
 
   console.log('\n[INFO] All notifications sent successfully');
 };


### PR DESCRIPTION
Splits the notification-handling half out of #304 so it can merge independently of the GraphQL retries.

When the ui build fails to produce `nightliesBuildStatus.json`/`repoBuildStatus.json`, the notifier used to post a bare "Build Status - DD.MM.YYYY" header and nothing else — indistinguishable from everything being fine. This makes it:

- degrade gracefully: load all status files up front, skip areas with no data, and only post the header when there is something to report;
- say so when data is partial (⚠️ names the missing files + pipeline link) or entirely absent (🚨 "No build status to report"), and fail the job so it stays visible.

Does **not** include the GraphQL retries from #304 — those are in #307, to hold until master is green per review feedback.

No Jira ticket.