### PR TITLE
fix(nightlies): retry GitLab/GitHub GraphQL and keep pipeline details serializable

### DIFF
--- a/ui/pages/build-status.js
+++ b/ui/pages/build-status.js
@@ -3,10 +3,11 @@ import { Accordion, AccordionDetails, AccordionSummary, Stack, Typography } from
 
 import { existsSync } from 'fs';
 import fs from 'fs/promises';
-import { gql, request } from 'graphql-request';
+import { gql } from 'graphql-request';
 
 import Link from '../components/link';
 import { buildStatusColor } from '../src/constants';
+import { requestWithRetry } from '../src/graphql';
 
 const areas = {
   backend: 'backend',
@@ -290,7 +291,7 @@ const getAllRepos = async () => {
   let hasNextPage = true;
 
   while (hasNextPage) {
-    const repoState = await request({
+    const repoState = await requestWithRetry({
       url: githubGraphqlUrl,
       variables: { login: 'mendersoftware', cursor },
       document: repoQuery,
@@ -375,7 +376,7 @@ const getAllProjects = async (group, ref) => {
   let hasNextPage = true;
 
   while (hasNextPage) {
-    const data = await request({
+    const data = await requestWithRetry({
       url: gitlabGraphqlUrl,
       document: pipelineQuery,
       variables: { group: `Northern.tech/${group}`, ref, cursor },

--- a/ui/pages/nightlies.js
+++ b/ui/pages/nightlies.js
@@ -5,8 +5,9 @@ import { Box, ToggleButton, ToggleButtonGroup, Typography } from '@mui/material'
 
 import dayjs from 'dayjs';
 import fs from 'fs/promises';
-import { gql, request } from 'graphql-request';
+import { gql } from 'graphql-request';
 
+import { requestWithRetry } from '../src/graphql';
 import { PipelineCalendar } from '../src/nightlies/CalendarView';
 import { Legend } from '../src/nightlies/Legend';
 import { PipelineListView } from '../src/nightlies/ListView';
@@ -190,15 +191,18 @@ const calculateRetryInfo = jobs => {
   };
 };
 
-const emptyDetails = {
+// keep the pipeline identity around even when we couldn't enrich it, so the repo can still be named and linked
+// downstream - an absent buildStatus would fail the static export, as `undefined` is not serializable
+const emptyDetails = pipeline => ({
   testReportSummary: { total: { failed: 0 } },
   hasRetries: false,
-  retriedJobCount: 0
-};
+  retriedJobCount: 0,
+  buildStatus: { name: pipeline.name, fullPath: pipeline.projectPath, status: '' }
+});
 const getPipelineDetails = async (pipeline, pipelineIid) => {
   let pipelineData;
   try {
-    const data = await request({
+    const data = await requestWithRetry({
       url: gitlabGraphqlUrl,
       document: pipelineEnrichmentQuery,
       variables: {
@@ -210,11 +214,11 @@ const getPipelineDetails = async (pipeline, pipelineIid) => {
     pipelineData = data?.project?.pipeline;
   } catch (error) {
     console.error(`(${pipeline.name}): GraphQL query failed for pipeline ${pipelineIid}:`, error);
-    return emptyDetails;
+    return emptyDetails(pipeline);
   }
   if (!pipelineData) {
     console.warn(`Failed to fetch details for pipeline ${pipelineIid}`);
-    return emptyDetails;
+    return emptyDetails(pipeline);
   }
   const retryInfo = calculateRetryInfo(pipelineData.jobs?.nodes || []);
   const failedJobs = (pipelineData.jobs?.nodes || []).filter(({ status }) => status === 'FAILED');

--- a/ui/src/graphql.js
+++ b/ui/src/graphql.js
@@ -1,0 +1,26 @@
+import { request } from 'graphql-request';
+
+const maxRetries = 3;
+
+// GitLab and GitHub regularly answer with a 502/503 from their edge, occasionally rate limit us and sometimes just
+// drop the connection - none of which says anything about the query itself, so those are worth another attempt
+const isRetriable = error => {
+  const status = error?.response?.status;
+  return status === undefined || status === 429 || status >= 500;
+};
+
+export const requestWithRetry = async options => {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      return await request(options);
+    } catch (error) {
+      if (attempt === maxRetries || !isRetriable(error)) {
+        throw error;
+      }
+      const delay = Math.pow(2, attempt) * 1000;
+      const reason = error?.response?.status ?? 'a network error';
+      console.warn(`(GraphQL ${new URL(options.url).host}): attempt ${attempt}/${maxRetries} failed with ${reason}, retrying in ${delay}ms`);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+};


### PR DESCRIPTION
Splits the GraphQL-retry half out of #304 per review feedback, so it can be held until master is green and its impact on rate limits can be measured cleanly.

Root cause of the empty Slack reports: a transient GitLab 502 on the nightlies GraphQL query fell through to `emptyDetails`, which had no `buildStatus` field → `undefined` → Next.js `getStaticProps` serialization crash → `/nightlies` build fails → no artifact → notifier has nothing to report.

- `emptyDetails` now carries a `buildStatus` so the props stay serializable even when GitLab fails;
- adds `requestWithRetry` (exp. backoff, retries only on 5xx/429/network) and routes the nightlies + build-status GraphQL calls through it.

**Note on rate limits (raised in #304):** retries fire only on 5xx/429/network errors, capped at 3 attempts with 2s/4s/8s backoff — they do not retry ordinary 4xx. Holding this until master is green, as requested, so the baseline is measurable.

Companion to #306 (notification handling). No Jira ticket.